### PR TITLE
audit response: docs overhaul

### DIFF
--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -1,0 +1,50 @@
+name: Require linked issue
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    if: >-
+      !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+      && !endsWith(github.actor, '[bot]')
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const body = pr.body || '';
+            // Matches: Closes #1, Fixes owner/repo#1, Resolves https://github.com/owner/repo/issues/1
+            const pattern = /\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+(#\d+|[\w.-]+\/[\w.-]+#\d+|https?:\/\/github\.com\/[\w.-]+\/[\w.-]+\/issues\/\d+)/i;
+            if (pattern.test(body)) {
+              core.info('Linked issue found in PR body.');
+              return;
+            }
+            const contributingUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/blob/master/CONTRIBUTING.md`;
+            const message = [
+              "Hi, and thanks for the contribution!",
+              "",
+              `This PR doesn't appear to be linked to an open issue. Per [CONTRIBUTING.md](${contributingUrl}), all pull requests to this repo must close an issue that's already been acknowledged by a maintainer.`,
+              "",
+              "Please open an issue describing the change you'd like to make, wait for a thumbs-up from a maintainer, then submit a new PR with `Closes #N` in the description.",
+              "",
+              "Auto-closing this PR — no hard feelings, just keeping the queue manageable."
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body: message,
+            });
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              state: 'closed',
+            });

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,103 @@
+# Contributing to c3kit-bucket
+
+c3kit-bucket is a small Clojure/ClojureScript library providing a unified data API across Datomic, SQL databases, IndexedDB, and in-memory stores. Contributions are welcome — keep PRs focused and the scope small.
+
+## Branching
+
+Branch off `master`. PRs must pass CI before merge.
+
+## Running tests locally
+
+### Clojure
+
+```bash
+clj -M:test:spec          # run once
+clj -M:test:spec -a       # auto runner
+```
+
+CI runs with `:spec-ci` (no `-t ~slow` filter) — use that when you want the full suite:
+
+```bash
+clj -M:test:spec-ci
+```
+
+### ClojureScript
+
+```bash
+clj -M:test:cljs once     # run once
+clj -M:test:cljs          # auto runner
+```
+
+### IndexedDB integration
+
+```bash
+clojure -M:test:idb-integration
+```
+
+This launches a headless browser runner. It requires Node/npm tooling on your PATH (handled automatically in CI).
+
+## Database infrastructure for the full SQL suite
+
+CI runs PostgreSQL, MSSQL, and SQLite. Without local instances the JDBC specs will be skipped or will fail.
+
+**PostgreSQL**
+
+```bash
+sudo -u postgres createuser $(whoami)
+sudo -u postgres createdb test
+sudo -u postgres psql -d test -c "GRANT ALL ON SCHEMA public TO PUBLIC;"
+```
+
+**MSSQL**
+
+Run via Docker:
+
+```bash
+docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=Pala2023" \
+  -p 1433:1433 \
+  mcr.microsoft.com/mssql/server:2019-CU27-ubuntu-20.04
+```
+
+Then create the database:
+
+```bash
+sqlcmd -S localhost -U sa -P Pala2023 -Q "CREATE DATABASE bucketTest" -C
+```
+
+**SQLite**
+
+SQLite is usually pre-installed. The `sqlite-vec` extension is required for vector tests:
+
+```bash
+pip install sqlite-vec
+export SQLITE_VEC_PATH=$(python3 -c 'import sqlite_vec; print(sqlite_vec.loadable_path())')
+```
+
+## Updating CHANGES.md
+
+Every consumer-visible change — new features, bug fixes, behaviour changes — gets a bullet under the relevant version header in `CHANGES.md`. Pure repo cleanup or doc-only changes don't need an entry.
+
+## Code style
+
+No project-wide formatter. Aim for idiomatic Clojure consistent with the surrounding code. See the formatting notes in the project's internal style docs if in doubt.
+
+## Releasing (maintainers only)
+
+You must be a member of the Clojars group `com.cleancoders.c3kit`.
+
+1. Go to <https://clojars.org/tokens> and create a deploy token scoped to the group.
+2. Export credentials:
+
+```bash
+export CLOJARS_USERNAME=<your username>
+export CLOJARS_PASSWORD=<your deploy token>
+```
+
+3. Update the `VERSION` file.
+4. Deploy:
+
+```bash
+clj -T:build deploy
+```
+
+This tags the commit, builds the jar, and pushes to Clojars in one step.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,17 @@
 
 c3kit-bucket is a small Clojure/ClojureScript library providing a unified data API across Datomic, SQL databases, IndexedDB, and in-memory stores. Contributions are welcome — keep PRs focused and the scope small.
 
-## Branching
+## Workflow
 
-Branch off `master`. PRs must pass CI before merge.
+**All pull requests must be linked to an open issue.** PRs without a linked issue will be auto-closed without review by the [`require-linked-issue`](./.github/workflows/require-linked-issue.yml) workflow. Open (or find) an issue first, get a thumbs-up from a maintainer, then start work. This protects everyone's time — yours and ours.
+
+1. Open or find an issue describing the bug or proposed change. Wait for maintainer acknowledgement before starting work on anything non-trivial.
+2. Branch off `master`.
+3. Use TDD — write a failing spec first, then the minimum code to make it pass, then refactor.
+4. Keep commits small and focused.
+5. Update `CHANGES.md` with a one-line entry under the relevant version header (skip for doc-only or repo cleanup).
+6. Reference the issue with `Closes #N` (or `Fixes #N` / `Resolves #N`) in your PR description so the linked-issue check passes and the issue auto-closes on merge.
+7. Ensure CI is green before requesting review.
 
 ## Running tests locally
 

--- a/README.md
+++ b/README.md
@@ -8,29 +8,118 @@ _"Most men give advice by the bucket, but take it by the grain."_ - William R. A
 
 [![Bucket Build](https://github.com/cleancoders/c3kit-bucket/actions/workflows/test.yml/badge.svg)](https://github.com/cleancoders/c3kit-bucket/actions/workflows/test.yml)
 
-Bucket offers an identical API for dealing with data on both the server side (datomic), and the client side (in memory), in addition to other goodies.
+## What is bucket?
 
- * __bg.clj__ : background task management
- * __db.clj__ : simple api for datomic interaction
- * __migrate.clj__ : manage and execute migration scripts
- * __spec_helper.clj__ : to easily test client code
- * __hashid.cljc__ : platform independent hashid
- * __db.cljs__ : simple api for in-memory data storage and retrieval
- * __spec_helper.cljs__ : to easily test client code
+Bucket is a unified entity-storage API for Clojure and ClojureScript. The same domain code runs against any supported backend — Datomic, JDBC (Postgres, H2, MSSQL, SQLite), in-memory, and IndexedDB — because every backend implements the same `c3kit.bucket.api/DB` protocol. Define your schemas once with [c3kit-apron](https://github.com/cleancoders/c3kit-apron), then transact, query, and look up entities through `c3kit.bucket.api` regardless of where the data lives.
 
-# Development
+## Installation
 
-    # Run the JVM tests
-    clj -M:test:spec
-    clj -M:test:spec -a         # auto runner
+**deps.edn**
 
-    # Compile and Run JS tests
-    clj -M:test:cljs once
-    clj -M:test:cljs            # auto runner
+```clojure
+{:deps {com.cleancoders.c3kit/bucket {:mvn/version "2.13.1"}}}
+```
 
-### PostgreSQL
+**Leiningen**
 
-Run the commands to set up postgresql:
+```clojure
+[com.cleancoders.c3kit/bucket "2.13.1"]
+```
+
+## Hello World
+
+The following example uses the explicit-db API (`tx-`, `find-by-`, `entity-`), which works without any global state setup and runs in a plain `clj` REPL once the dep is on the classpath.
+
+```clojure
+(require '[c3kit.apron.schema :as s]
+         '[c3kit.bucket.api :as db]
+         '[c3kit.bucket.memory])  ; loads the :memory backend
+
+;; Define a schema
+(def widget
+  {:kind  (s/kind :widget)
+   :id    s/id
+   :name  {:type :string}
+   :color {:type :keyword}})
+
+;; Create an in-memory database
+(def my-db (db/create-db {:impl :memory} [widget]))
+
+;; Save an entity (explicit-db variant)
+(db/tx- my-db {:kind :widget :name "Sprocket" :color :red})
+;; => {:kind :widget, :id 1001, :name "Sprocket", :color :red}
+
+;; Find by attribute (returns a lazy seq)
+(db/find-by- my-db :widget :name "Sprocket")
+;; => ({:kind :widget, :id 1001, :name "Sprocket", :color :red})
+
+;; Look up by id
+(db/entity- my-db :widget 1001)
+;; => {:kind :widget, :id 1001, :name "Sprocket", :color :red}
+```
+
+The id value (`1001` above) is auto-generated and will vary. The same code shape works against any supported backend; only the `{:impl ...}` config map passed to `create-db` changes.
+
+## Supported backends
+
+| Impl key | Platform | Notes | Guide |
+|---|---|---|---|
+| `:memory` | CLJ / CLJS | In-process, ephemeral | — |
+| `:re-memory` | CLJS | Reagent-aware in-memory | — |
+| `:jdbc` | CLJ | Postgres, H2, MSSQL, SQLite (+ pgvector, sqlite-vec) | — |
+| `:datomic` | CLJ | Datomic on-prem (peer) | [docs/datomic-guide.md](docs/datomic-guide.md) |
+| `:datomic-cloud` | CLJ | Datomic Cloud (client) | [docs/datomic-guide.md](docs/datomic-guide.md) |
+| `:indexeddb` | CLJS | Browser persistent storage | [docs/indexeddb-guide.md](docs/indexeddb-guide.md) |
+| `:re-indexeddb` | CLJS | Reagent-aware IndexedDB | [docs/indexeddb-guide.md](docs/indexeddb-guide.md) |
+
+## Core concepts
+
+### Schemas
+
+Schemas are plain Clojure maps validated by [c3kit-apron](https://github.com/cleancoders/c3kit-apron). Every entity schema has a `:kind` declaration (via `s/kind`), an `:id` field, and attribute definitions that describe the type of each field.
+
+```clojure
+(def order
+  {:kind     (s/kind :order)
+   :id       s/id
+   :status   {:type :keyword}
+   :subtotal {:type :bigdec}
+   :placed-at {:type :instant}})
+```
+
+Attribute types include `:string`, `:keyword`, `:long`, `:int`, `:boolean`, `:instant`, `:bigdec`, `:ref`, and collection types like `[:string]` (a sequence of strings). See the apron docs for the full type reference.
+
+### The DB protocol
+
+Every backend implements `c3kit.bucket.api/DB`. Consumers typically call the wrapper functions in `c3kit.bucket.api` (`tx`, `find`, `find-by`, `ffind`, `ffind-by`, `entity`, `entity!`, `count`, `delete`, `reload`, etc.).
+
+Each wrapper has an **explicit-db variant** suffixed with `-` (e.g. `tx-`, `find-by-`, `entity-`) that accepts a DB instance as its first argument. Use these variants when working with multiple databases in the same process, or to avoid touching the global `impl` atom.
+
+## Migrations
+
+Bucket includes a migration system for evolving your schema over time. Migrations are Clojure namespaces with numbered naming conventions; the migrator tracks which have run and executes new ones in order. See [docs/migrations-guide.md](docs/migrations-guide.md) for setup and usage.
+
+## Background tasks
+
+`c3kit.bucket.bg` provides a lightweight scheduled-task manager backed by a `ScheduledThreadPoolExecutor`. Tasks are registered by key and store a `:last-ran-at` timestamp in the database, allowing persistent scheduling across restarts. Refer to the docstrings in `src/clj/c3kit/bucket/bg.clj` for the full public API.
+
+## Development
+
+### Running tests
+
+```bash
+# JVM tests
+clj -M:test:spec
+clj -M:test:spec -a        # auto runner
+
+# ClojureScript tests
+clj -M:test:cljs once
+clj -M:test:cljs           # auto runner
+```
+
+The full SQL suite requires Postgres, MSSQL, SQLite, and sqlite-vec to be available locally. See [CONTRIBUTING.md](CONTRIBUTING.md) for environment setup details.
+
+### PostgreSQL local setup
 
 ```
 $ sudo -u postgres createuser $(whoami)
@@ -38,18 +127,10 @@ $ sudo -u postgres createdb test
 $ sudo -u postgres psql -d test -c "GRANT ALL ON SCHEMA public TO PUBLIC;"
 ```
 
-# Deployment
+## Contributing
 
-In order to deploy to c3kit you must be a member of the Clojars group `com.cleancoders.c3kit`.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development workflow, environment setup, and the release process.
 
-1. Go to https://clojars.org/tokens and configure a token with the appropriate scope
-2. Set the following environment variables
+## License
 
-```
-CLOJARS_USERNAME=<your username>
-CLOJARS_PASSWORD=<your deploy key>
-```
-
-3. Update VERSION file
-4. `clj -T:build deploy`
-
+MIT — see [LICENSE](LICENSE).

--- a/docs/datomic-guide.md
+++ b/docs/datomic-guide.md
@@ -1,0 +1,306 @@
+# c3kit.bucket Datomic Developer Guide
+
+A guide to the Datomic-specific features available beyond the unified `c3kit.bucket.api`.
+
+## Overview
+
+Both Datomic backends implement the standard `api/DB` protocol, so `db/tx`, `db/find-by`, `db/entity`, and friends work identically across all backends. The Datomic implementations add a substantial layer on top: entity history, time-travel reads, raw datalog queries, aggregate finders, and timestamp helpers. The two backends — on-prem peer (`:datomic`) and Cloud client (`:datomic-cloud`) — share most of this surface but differ in connection config, schema indexing, query result format, and a handful of functions that exist on only one side.
+
+## Choosing On-Prem vs Cloud
+
+| | `:datomic` (on-prem peer) | `:datomic-cloud` |
+|---|---|---|
+| Library | `com.datomic/datomic-pro` or `datomic-free` | `com.datomic/client-cloud` |
+| Storage | In-memory, SQL, DynamoDB, Cassandra | DynamoDB via Datomic Cloud service |
+| Local dev | `datomic:mem://` | `:datomic-local` with `:storage-dir :mem` |
+| Aggregate queries | `find-min*` / `find-max*` available | Not available |
+| `squuid` | Built-in via `datomic.api/squuid` | Not available |
+| `tx-ids` | Not available | Available |
+| `:db/index` | Respected | Ignored |
+
+Pick `:datomic` when you self-host Datomic Pro/Free, need aggregate helpers, or want `squuid`. Pick `:datomic-cloud` when you run Datomic Cloud on AWS and want managed infrastructure.
+
+## Connection Setup: On-Prem (`:datomic`)
+
+```clojure
+(ns my-app.db
+  (:require [c3kit.bucket.api :as db]
+            [c3kit.bucket.datomic]       ;; registers :datomic impl
+            [my-app.schema :as schema]))
+
+(def config
+  {:impl      :datomic
+   :uri       "datomic:mem://my-app"   ;; or datomic:ddb://... / datomic:sql://...
+   :partition :my-app})                ;; optional; defaults to :db.part/user
+
+(defn install-db! []
+  (db/set-impl! (db/create-db config schema/all-schemas)))
+```
+
+### URI Formats
+
+| URI | Storage |
+|-----|---------|
+| `datomic:mem://my-app` | In-memory (dev/test) |
+| `datomic:ddb://us-east-1/my-table/my-db` | DynamoDB |
+| `datomic:sql://my-db?jdbc:postgresql://host/db` | SQL (Postgres, MySQL, etc.) |
+
+The peer library connects directly to storage. `create-db` calls `datomic.api/create-database` followed by `datomic.api/connect`, so the database is created if it does not already exist.
+
+## Connection Setup: Cloud (`:datomic-cloud`)
+
+```clojure
+(ns my-app.db
+  (:require [c3kit.bucket.api :as db]
+            [c3kit.bucket.datomic-cloud]  ;; registers :datomic-cloud impl
+            [my-app.schema :as schema]))
+
+(def config
+  {:impl          :datomic-cloud
+   :server-type   :datomic-local    ;; or :ion for deployed Cloud
+   :storage-dir   :mem              ;; :mem for local; path for file-backed local
+   :creds-profile "sandbox"
+   :system        "my-system"
+   :db-name       "my-app"
+   :endpoint      "https://<api-id>.execute-api.us-east-1.amazonaws.com/"
+   :region        "us-east-1"})
+
+(defn install-db! []
+  (db/set-impl! (db/create-db config schema/all-schemas)))
+```
+
+For production Cloud, set `:server-type :ion` and supply real `:endpoint`, `:region`, `:system`, and `:creds-profile` values. For local development, use `:server-type :datomic-local` with `:storage-dir :mem` (ephemeral) or `:storage-dir "/path/to/dir"` (durable). The spec suite config above is a real example straight from the test namespace.
+
+`create-db` calls `datomic.client.api/client` to build a client, then `datomic.client.api/create-database` and `datomic.client.api/connect`.
+
+## Schema Mapping
+
+Apron schema specs translate to Datomic attributes via the optional `:db` option vector on each attribute spec.
+
+```clojure
+(def order
+  {:kind    (s/kind :order)
+   :id      s/id
+   :number  {:type :string  :db [:unique-value]}
+   :email   {:type :string  :db [:unique-identity :index]}
+   :notes   {:type :string  :db [:fulltext]}
+   :items   {:type [:ref]   :db [:component]}
+   :total   {:type :bigdec  :db [:no-history]}})
+```
+
+### `:db` Options
+
+| Option | Datomic attribute | Effect |
+|--------|-------------------|--------|
+| `:index` | `:db/index true` | Secondary index (on-prem only — ignored on Cloud) |
+| `:unique-value` | `:db/unique :db.unique/value` | Value unique across all entities; upsert-by-value not allowed |
+| `:unique-identity` | `:db/unique :db.unique/identity` | Value unique; supports upsert by this attribute |
+| `:component` | `:db/isComponent true` | Cascades retraction to referenced entity |
+| `:no-history` | `:db/noHistory true` | Skips history storage for this attribute |
+| `:fulltext` | `:db/fulltext true` | Full-text search index |
+
+**Cloud ignores `:db/index`.** The `spec->attribute` function accepts an `index-allowed?` flag; on-prem passes `true` and Cloud passes `false`, so `:db/index` is never included in Cloud schema transactions.
+
+### Enum Schemas
+
+Enums install Datomic ident datoms for use as keyword references:
+
+```clojure
+(def order-status
+  {:enum   :order.status
+   :values [:pending :processing :shipped :cancelled]})
+
+;; Usage in an entity schema:
+(def order
+  {:kind   (s/kind :order)
+   :id     s/id
+   :status {:type :kw-ref}})
+```
+
+Pass both schemas in the `schemas` vector to `create-db`.
+
+## Entity History and Time-Travel
+
+Both backends share the history API, exposed as namespace-level functions (not on the `api/DB` protocol).
+
+### `history`
+
+Returns every version of an entity from creation to current state. Each entry carries `:db/tx` (transaction id) and `:db/instant` (java.util.Date).
+
+```clojure
+(require '[c3kit.bucket.datomic :as datomic])   ;; or datomic-cloud
+
+(let [history (datomic/history order)]
+  (doseq [version history]
+    (println (:db/instant version) (:status version))))
+```
+
+### `created-at` / `updated-at` / `with-timestamps`
+
+```clojure
+(datomic/created-at order)     ;; => #inst "2024-01-15T..."
+(datomic/updated-at order)     ;; => #inst "2024-03-20T..."
+
+;; Attach both to the entity map
+(datomic/with-timestamps order)
+;; => {:kind :order ... :db/created-at #inst "..." :db/updated-at #inst "..."}
+```
+
+Both functions accept either an entity map or a raw entity id (long).
+
+### `db-as-of`
+
+Read the database as it existed at a point in time. Pass a transaction id or a `java.util.Date`:
+
+```clojure
+(require '[c3kit.bucket.datomic :as datomic])
+
+(let [snapshot (datomic/db-as-of some-tx-id)]
+  ;; snapshot is a Datomic db value at that transaction
+  ...)
+```
+
+### `excise!`
+
+Removes an entity from history entirely:
+
+```clojure
+(datomic/excise! order)
+;; or
+(datomic/excise! (:id order))
+```
+
+**Caveat:** Datomic excision is asynchronous at the index level. The entity disappears from queries only after the next indexing job completes. Do not rely on the entity being absent immediately after `excise!` returns.
+
+## Datomic-Specific Query Functions
+
+### `q` — Raw Datalog
+
+Runs a raw datalog query against the current database value:
+
+```clojure
+(require '[c3kit.bucket.datomic :as datomic])
+
+;; on-prem: finds entity ids matching the clause
+(datomic/q '[:find ?e
+             :where [?e :order/status :order.status/pending]])
+```
+
+Additional args after the query are passed as datalog `:in` bindings:
+
+```clojure
+(datomic/q '[:find ?e
+             :in $ ?status
+             :where [?e :order/status ?status]]
+           :order.status/pending)
+```
+
+### `find-datalog` — Entity-Returning Queries
+
+Runs a datalog query and returns results as hydrated entity maps. **The query syntax differs between backends:**
+
+**On-prem** — use `?e` in `:find`; the library resolves entity ids to maps:
+
+```clojure
+;; c3kit.bucket.datomic
+(datomic/find-datalog '[:find ?e
+                        :in $
+                        :where [?e :order/number]])
+;; => ({:kind :order :id 123 :number "ORD-001" ...} ...)
+```
+
+**Cloud** — use `(pull ?e [*])` in `:find`; the library extracts the pulled maps:
+
+```clojure
+;; c3kit.bucket.datomic-cloud
+(datomic-cloud/find-datalog '[:find (pull ?e [*])
+                               :in $
+                               :where [?e :order/number]])
+;; => ({:kind :order :id 123 :number "ORD-001" ...} ...)
+```
+
+The return value is the same shape — entity maps with `:kind` and unqualified keys. Only the query syntax differs.
+
+### `squuid` — Time-Based UUIDs (On-Prem Only)
+
+Generates a UUID whose high bits encode the current time, making UUIDs sortable by creation time:
+
+```clojure
+(require '[c3kit.bucket.datomic :as datomic])
+
+(datomic/squuid)  ;; => #uuid "5ebe2294-1234-5678-..."
+```
+
+`squuid` is a direct alias for `datomic.api/squuid`. It is **not available on Cloud**.
+
+## Aggregate Queries: find-min / find-max (On-Prem Only)
+
+These functions find the entity with the extreme value of an attribute across all entities of a kind.
+
+```clojure
+(require '[c3kit.bucket.datomic :as datomic])
+
+;; Entity with the highest :total
+(datomic/find-max-of-all :order :total)
+;; => {:kind :order :id 456 :total 9999.99M ...}
+
+;; Just the max value
+(datomic/find-max-val-of-all :order :total)
+;; => 9999.99M
+
+;; Entity with the lowest :total
+(datomic/find-min-of-all :order :total)
+;; => {:kind :order :id 789 :total 0.99M ...}
+
+;; Just the min value
+(datomic/find-min-val-of-all :order :total)
+;; => 0.99M
+```
+
+All four functions have `-` variants that accept an explicit db instance as first arg (e.g., `find-max-of-all-`), mirroring the pattern used throughout the library.
+
+**These functions do not exist on `c3kit.bucket.datomic-cloud`.**
+
+## Partitions (On-Prem Only)
+
+On-prem Datomic organizes entities into partitions. c3kit.bucket defaults to `:db.part/user`. To use a custom partition, add `:partition` to the config:
+
+```clojure
+{:impl      :datomic
+ :uri       "datomic:mem://my-app"
+ :partition :my-app}
+```
+
+The partition must be installed before entities are written. You can transact the partition schema directly:
+
+```clojure
+(require '[c3kit.bucket.datomic-common :as datomic-common])
+
+(datomic-common/transact! (datomic-common/partition-schema :my-app))
+```
+
+Partition config is ignored on Cloud — Cloud uses a single default partition.
+
+## API Surface Differences
+
+| Feature | `:datomic` | `:datomic-cloud` |
+|---------|-----------|-----------------|
+| `history` | `c3kit.bucket.datomic/history` | `c3kit.bucket.datomic-cloud/history` |
+| `created-at` | `c3kit.bucket.datomic/created-at` | `c3kit.bucket.datomic-cloud/created-at` |
+| `updated-at` | `c3kit.bucket.datomic/updated-at` | `c3kit.bucket.datomic-cloud/updated-at` |
+| `with-timestamps` | `c3kit.bucket.datomic/with-timestamps` | `c3kit.bucket.datomic-cloud/with-timestamps` |
+| `excise!` | `c3kit.bucket.datomic/excise!` | `c3kit.bucket.datomic-cloud/excise!` |
+| `q` | `c3kit.bucket.datomic/q` | `c3kit.bucket.datomic-cloud/q` |
+| `find-datalog` | `c3kit.bucket.datomic/find-datalog` | `c3kit.bucket.datomic-cloud/find-datalog` |
+| `db-as-of` | `c3kit.bucket.datomic/db-as-of` | `c3kit.bucket.datomic-cloud/db-as-of` |
+| `squuid` | `c3kit.bucket.datomic/squuid` | **not available** |
+| `find-max-of-all` | `c3kit.bucket.datomic/find-max-of-all` | **not available** |
+| `find-max-val-of-all` | `c3kit.bucket.datomic/find-max-val-of-all` | **not available** |
+| `find-min-of-all` | `c3kit.bucket.datomic/find-min-of-all` | **not available** |
+| `find-min-val-of-all` | `c3kit.bucket.datomic/find-min-val-of-all` | **not available** |
+| `tx-ids` | **not available** | `c3kit.bucket.datomic-cloud/tx-ids` |
+| `:partition` config | Supported | Ignored |
+| `:db/index` schema option | Respected | Ignored |
+| `transact` return | future (deref'd internally) | synchronous |
+| `tempid` type | `datomic.db.DbId` | negative integer |
+| `find-datalog` query | `[:find ?e ...]` | `[:find (pull ?e [*]) ...]` |

--- a/docs/migrations-guide.md
+++ b/docs/migrations-guide.md
@@ -13,16 +13,19 @@ Migrations live in a dedicated namespace directory. Set `:migration-ns` in your 
  :migration-ns "my.app.migrations"}
 ```
 
-The runner scans `my/app/migrations/` on the classpath for files matching `[0-9]{8}.*\.clj` — eight leading digits followed by any suffix. Files are sorted lexicographically, so the digits act as a timestamp. The recommended convention is `YYYYMMDD` optionally followed by a short description:
+The runner scans `my/app/migrations/` on the classpath for files matching `[0-9]{8}.*\.clj` — eight leading digits followed by any suffix. Files are sorted lexicographically, so the digits act as a timestamp. The recommended convention is `YYYYMMDD` optionally followed by a short description.
+
+When you need multiple migrations on the same date, append a letter suffix (`a`, `b`, `c`, …) directly after the digits so lex order matches the intended run order:
 
 ```
 my/app/migrations/
   20230101.clj
   20230202-add-user-email.clj
-  20230303-drop-legacy-kind.clj
+  20230303a-drop-legacy-kind.clj
+  20230303b-add-replacement-kind.clj
 ```
 
-Names that don't match the eight-digit pattern are silently ignored by the runner.
+Files without eight leading digits don't match the pattern and aren't picked up by the runner.
 
 ### Migration Script Shape
 
@@ -54,6 +57,12 @@ Use the `c3kit.bucket.migrator` API inside migration functions:
 | `migrator/add-attribute!` | Adds an attribute to an existing kind |
 | `migrator/remove-attribute!` | Removes an attribute (and all its values) |
 | `migrator/rename-attribute!` | Renames an attribute within a kind |
+
+### Going Deeper
+
+For more substantive migrations — multi-step data transforms, cross-kind moves, performance considerations on large tables — read [Facing Migrations With Respect](https://cleancoders.com/blog/2025-02-13-facing-migrations-with-respect). It covers the conventions and discipline this project's migrations follow.
+
+If you're working in Claude Code, the [`writing-migrations` skill](https://github.com/cleancoders/agent-plugins/blob/master/plugins/clojure/skills/writing-migrations/SKILL.md) in the `clojure` plugin walks you through the same conventions step-by-step.
 
 ## Running Migrations
 

--- a/docs/migrations-guide.md
+++ b/docs/migrations-guide.md
@@ -1,0 +1,199 @@
+# Migrations
+
+`c3kit.bucket.migration` runs versioned migration scripts against your database. Each migration is a Clojure namespace with `up` and `down` functions. The runner compares what's on disk against what has been applied (tracked as `:migration` entities in your DB) and runs whatever is needed to reach the target.
+
+## Writing a Migration
+
+### File Location and Naming
+
+Migrations live in a dedicated namespace directory. Set `:migration-ns` in your bucket config to point to it:
+
+```clojure
+{:impl         :datomic
+ :migration-ns "my.app.migrations"}
+```
+
+The runner scans `my/app/migrations/` on the classpath for files matching `[0-9]{8}.*\.clj` — eight leading digits followed by any suffix. Files are sorted lexicographically, so the digits act as a timestamp. The recommended convention is `YYYYMMDD` optionally followed by a short description:
+
+```
+my/app/migrations/
+  20230101.clj
+  20230202-add-user-email.clj
+  20230303-drop-legacy-kind.clj
+```
+
+Names that don't match the eight-digit pattern are silently ignored by the runner.
+
+### Migration Script Shape
+
+Each migration file defines two zero-argument functions: `up` and `down`.
+
+```clojure
+(ns my.app.migrations.20230202-add-user-email
+  (:require [c3kit.bucket.migrator :as migrator]
+            [my.app.schema :as schema]))
+
+(defn up []
+  (migrator/install-schema! schema/user)
+  (migrator/add-attribute! :user :email {:type :string}))
+
+(defn down []
+  (migrator/remove-attribute! :user :email))
+```
+
+- `up` is called when migrating forward to this version.
+- `down` is called when rolling back past this version.
+- Both functions receive no arguments and return nothing meaningful.
+- Both are required by convention. The runner resolves `<migration-ns>.<name>/up` and `<migration-ns>.<name>/down` at runtime; a missing `down` will cause a runtime error if rollback is attempted.
+
+Use the `c3kit.bucket.migrator` API inside migration functions:
+
+| Function | Description |
+|----------|-------------|
+| `migrator/install-schema!` | Creates a new kind in the database schema |
+| `migrator/add-attribute!` | Adds an attribute to an existing kind |
+| `migrator/remove-attribute!` | Removes an attribute (and all its values) |
+| `migrator/rename-attribute!` | Renames an attribute within a kind |
+
+## Running Migrations
+
+### From the CLI
+
+Add a `:migrate` alias to your `deps.edn` that points to `c3kit.bucket.migration/-main` and starts your app services (including the bucket service):
+
+```clojure
+:migrate {:main-opts ["-m" "my.app.migrate"]}
+```
+
+Your entry point namespace starts the bucket service then delegates to `c3kit.bucket.migration/migrate`:
+
+```clojure
+(ns my.app.migrate
+  (:require [c3kit.bucket.api :as db]
+            [c3kit.bucket.migration :as migration]))
+
+(defn -main [& args]
+  (app/start! [db/service])
+  (apply migration/migrate args))
+```
+
+The built-in usage string (from `migration/migrate`):
+
+```
+**** c3kit migration USAGE:
+
+clj -Mmigrate:test [command | migration-name] [preview]
+
+ Commands:
+   help:  prints this message
+   sync:  synchronize the database schema with :full-schema-var
+   list:  show available and when they were applied
+ migration-name - e.g. 20220806-first
+   migrations will be applied UP or DOWN to make the named migration the latest applied
+ no arguments will migrate UP to latest migration
+ preview: migrations/syncing will not update the database
+```
+
+| Invocation | Behavior |
+|------------|----------|
+| `clj -M:migrate` | Migrate up to the latest available migration |
+| `clj -M:migrate 20230202-add-user-email` | Migrate up or down so that `20230202-add-user-email` is the latest applied |
+| `clj -M:migrate list` | Print all available migrations and when each was applied |
+| `clj -M:migrate sync` | Run schema sync (see [Schema Sync](#schema-sync)) |
+| `clj -M:migrate help` | Print the usage string |
+| `clj -M:migrate <any command> preview` | Dry-run: log what would happen but do not write to the database |
+
+### From the REPL or Tests
+
+`migrate!` is the public programmatic entry point. It reads `:migration-ns` from the config you pass and requires the bucket DB impl to be present:
+
+```clojure
+(require '[c3kit.bucket.migration :as migration])
+
+;; migrate up to latest
+(migration/migrate! config)
+
+;; migrate to a specific version
+(migration/migrate! config "20230202-add-user-email")
+```
+
+`config` must contain:
+- `:-db` — the bucket DB impl (e.g., `@db/impl`)
+- `:migration-ns` — namespace string where migration files live
+
+When using the app service system, `migrate!` can be called with no arguments and will pull config from `app/app`:
+
+```clojure
+(migration/migrate!)
+```
+
+`c3kit.bucket.migration/service` is a ready-made app service that calls `migrate!` on start. Add it to your service startup sequence to run migrations automatically at boot:
+
+```clojure
+(app/start! [db/service migration/service])
+```
+
+## Schema Sync
+
+Schema sync (`sync-schemas!`) is a non-destructive operation that compares your in-code legend against what is actually installed in the database:
+
+- **Missing kinds** are created.
+- **Missing attributes** are added.
+- **Type mismatches** are logged as warnings.
+- **Extra attributes or kinds** in the DB are logged as warnings.
+- Nothing is removed or modified.
+
+```clojure
+;; programmatic
+(migration/sync-schemas! config schemas)
+
+;; or via no-arg form when app services are running
+(migration/sync-schemas!)
+```
+
+Sync runs at most once every 3 minutes. Subsequent calls within that window are skipped.
+
+**When to use sync vs. migrations:**
+
+Use **sync** during development or as a safety net on startup — it catches drift between your schema definitions and the live database. Use **migrations** for any structural change that needs to be applied in a controlled, ordered, reversible way in production.
+
+## How Migrations Are Tracked
+
+Applied migrations are stored as `:migration` entities in your configured database. Each entity has:
+
+```clojure
+{:kind :migration
+ :name "20230202-add-user-email"
+ :at   #inst "2023-02-15T..."}
+```
+
+Two sentinel records also live in the `:migration` kind:
+
+- `"LOCK"` — used for distributed locking (see below)
+- `"SYNC_SCHEMAS"` — tracks when schema sync last ran
+
+The migration schema is bootstrapped automatically on first run if it does not exist.
+
+## Locking
+
+The runner uses optimistic locking (`db/cas`) to prevent concurrent migrations. Before running, it acquires a lock by setting `:at` on the `LOCK` record. If another process holds the lock, the runner waits up to 10 seconds (checking every 250 ms) and then retries. The lock is always released in a `finally` block.
+
+In preview mode, locking is skipped.
+
+## Rollback
+
+Rolling back to an earlier migration (by passing a target name to `migrate!`) calls each migration's `down` function in reverse order — from the most recently applied migration down to (but not including) the target.
+
+Example: if migrations `20230101`, `20230202`, and `20230303` are applied and you run `(migrate! config "20230101")`, the runner calls `20230303/down` then `20230202/down`, leaving `20230101` as the latest applied.
+
+Each `down` call is executed sequentially. If a `down` function throws, the runner halts immediately — later `down` functions are not called. The migration record for the failed migration is **not** deleted, so the database tracking reflects what was actually completed. There is no automatic partial-rollback recovery; you must fix the failure and retry manually.
+
+## Backend Support
+
+The migration runner works against any backend that implements the `c3kit.bucket.migrator/Migrator` protocol:
+
+- In-memory (`:memory`) — supported; used in tests
+- JDBC (`:jdbc`, H2, Postgres, SQLite, SQL Server) — supported
+- Datomic (`:datomic-free`, `:datomic-client`, `:datomic-local`) — supported
+
+All major backends ship with `Migrator` implementations. The `migrator/migration-schema` multimethod defaults to `default-migration-schema` for all backends, so no backend-specific migration config is needed unless you override it.


### PR DESCRIPTION
## Summary

Documentation-only follow-up to PR #2 (audit response 2.13.1). Addresses the README weaknesses identified in the OSS readiness audit. **No version bump** — the JAR is unchanged; consumers continue to pull `2.13.1` from Clojars.

### What changed

- **README.md** rewritten for public consumers — installation snippets (deps.edn + Leiningen referencing 2.13.1), Hello World example using the unified API, supported-backends matrix, core concepts section, links to all guides
- **docs/migrations-guide.md** (new) — covers writing migrations, CLI usage, schema sync, locking, rollback, backend support
- **docs/datomic-guide.md** (new) — on-prem vs Cloud, connection setup, schema mapping, history/time-travel, datomic-specific queries, API surface differences between the two flavors
- **CONTRIBUTING.md** (new) — branch/PR conventions, local test commands, infra requirements for the full SQL suite, maintainer-only Clojars deploy steps
- README's old `# Deployment` section moved into `CONTRIBUTING.md`
- Stale namespace bullet list removed from README (referenced filenames that no longer exist)

### Verification

- All four doc links in README resolve to files that exist on this branch
- Hello World snippet was verified in a `clj` REPL; return values in the snippet match actual behavior
- No code changes — `clj -M:test:spec` still green at 618 examples / 0 failures (baseline from master)

## Test plan
- [ ] CI green (no code changes, but workflow still runs)
- [ ] Manual: skim README for typos and broken links
- [ ] Manual: confirm Hello World runs in a fresh REPL